### PR TITLE
Add gatsby-plugin keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "remark",
     "remark-abbr"
   ],


### PR DESCRIPTION
So it'll show up on https://www.gatsbyjs.org/packages/

You'll need to publish a new version with the new keyword.